### PR TITLE
PHP 8.2: Fix instances of 'Creation of dynamic properties' deprecation

### DIFF
--- a/src/widgets/Widget.php
+++ b/src/widgets/Widget.php
@@ -22,12 +22,17 @@ class Widget
     // Define asset manager
     public $config = false;
     protected $engine = false;
+    protected $engineCriteria = false;
     protected $manager = false;
     public $criteria = false;
     public $name = "core";
     public $added = false;
     public $sourceType = false;
     public $defaults = false;
+    public $range_start;
+    public $range_name;
+    public $range_start_raw;
+    public $range_end_raw;
 
     protected $options = [];
 


### PR DESCRIPTION
Hey there. I ran across this in our particular use-case. The deprecations are getting labeled as "Fatal Error" by ReporticoApp::ErrorHandler which is a little misleading. 

Anyhow, hope this is helpful.